### PR TITLE
Updating mediator maven archetype.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 *.i??
 .idea
 .iml
+
+# OS X temp files
+.DS_Store

--- a/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/pom.xml
@@ -76,7 +76,7 @@
         <carbon.gw.version>1.0.0-SNAPSHOT</carbon.gw.version>
         <slf4j.version>1.7.5</slf4j.version>
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>
-        <carbon.messaging.version>1.0.2</carbon.messaging.version>
+        <carbon.messaging.version>1.0.3</carbon.messaging.version>
         <osgi.api.version>6.0.0</osgi.api.version>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
@@ -89,6 +89,7 @@
         <import.package>
             org.osgi.framework.*;version="${osgi.framework.import.version.range}",
             org.wso2.carbon.gateway.core.*,
+            org.wso2.carbon.messaging.*,
             org.slf4j.*;version="${slf4j.logging.package.import.version.range}",
         </import.package>
 

--- a/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/src/main/java/__mediator_name__.java
+++ b/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/src/main/java/__mediator_name__.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package $package;
 
@@ -27,49 +27,50 @@ import org.wso2.carbon.messaging.CarbonMessage;
 
 
 /**
-* Mediator Implementation
+* Mediator Implementation.
 */
 public class ${mediator_name} extends AbstractMediator {
 
-  private static final Logger log = LoggerFactory.getLogger(${mediator_name}.class);
-  private String logMessage = "Message received at Sample Mediator";   // Sample Mediator specific variable
+    private static final Logger log = LoggerFactory.getLogger(${mediator_name}.class);
+    private String logMessage = "Message received at ${mediator_name} Mediator";   // ${mediator_name} Mediator
+    // specific variable
 
+    @Override
+    public String getName() {
+        return "${mediator_name}";
+    }
 
-  @Override
-  public String getName() {
-    return "${mediator_name}";
-  }
+    /**
+     * Mediate the message.
+     *
+     * This is the execution point of the mediator.
+     *
+     * @param carbonMessage  MessageContext to be mediated
+     * @param carbonCallback Callback which can be use to call the previous step
+     * @return whether mediation is success or not
+     */
+    @Override
+    public boolean receive(CarbonMessage carbonMessage, CarbonCallback carbonCallback) throws Exception {
+        log.info("Invoking ${mediator_name} Mediator");
+        log.info(logMessage);
+        return next(carbonMessage, carbonCallback); //Move forward
+    }
 
-  /**
-  * Mediate the message.
-  *
-  * This is the execution point of the mediator.
-  * @param carbonMessage MessageContext to be mediated
-  * @param carbonCallback Callback which can be use to call the previous step
-  * @return whether mediation is success or not
-  **/
-  @Override
-  public boolean receive(CarbonMessage carbonMessage, CarbonCallback carbonCallback) throws Exception {
-    log.info("Invoking ${mediator_name} Mediator");
-    log.info(logMessage);
-    return next(carbonMessage, carbonCallback); //Move forward
-  }
+    /**
+     * Set Parameters.
+     *
+     * @param parameterHolder holder which contains key-value pairs of parameters
+     */
+    @Override
+    public void setParameters(ParameterHolder parameterHolder) {
+        logMessage = parameterHolder.getParameter("parameters").getValue();
+    }
 
- /**
-  * Set Parameters
-  *
-  * @param parameterHolder holder which contains key-value pairs of parameters
-  */
-  @Override
-  public void setParameters(ParameterHolder parameterHolder) {
-    logMessage = parameterHolder.getParameter("parameters").getValue();
-  }
-
-
-  /** This is a sample mediator specific method */
-  public void setLogMessage(String logMessage) {
-     this.logMessage = logMessage;
-  }
-
+    /**
+     * This is a ${mediator_name} mediator specific method.
+     */
+    public void setLogMessage(String logMessage) {
+        this.logMessage = logMessage;
+    }
 
 }

--- a/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/src/main/java/__mediator_name__Provider.java
+++ b/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/src/main/java/__mediator_name__Provider.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package $package;
 
@@ -25,7 +25,7 @@ import org.wso2.carbon.gateway.core.flow.Mediator;
 import org.wso2.carbon.gateway.core.flow.MediatorProvider;
 
 /**
-* Mediator Provider Implementation
+* Mediator Provider Implementation.
 */
 @Component(
         name = "${mediator_name}Provider",
@@ -34,18 +34,18 @@ import org.wso2.carbon.gateway.core.flow.MediatorProvider;
 )
 public class ${mediator_name}Provider implements MediatorProvider {
 
-  @Activate
-  protected void start(BundleContext bundleContext) {
-  }
+    @Activate
+    protected void start(BundleContext bundleContext) {
+    }
 
-  @Override
-  public String getName() {
-    return "${mediator_name}";
-  }
+    @Override
+    public String getName() {
+        return "${mediator_name}";
+    }
 
-  @Override
-  public Mediator getMediator() {
-    return new ${mediator_name}();
-  }
+    @Override
+    public Mediator getMediator() {
+        return new ${mediator_name}();
+    }
 
 }

--- a/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/src/main/java/builder/__mediator_name__Builder.java
+++ b/archetypes/maven-archetype-mediator/src/main/resources/archetype-resources/src/main/java/builder/__mediator_name__Builder.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package ${package}.builder;
 
@@ -22,14 +22,15 @@ import $package.${mediator_name};
 import org.wso2.carbon.gateway.core.flow.Mediator;
 
 /**
-* Mediator Builder for Java DSL
+* Mediator Builder for Java DSL.
 */
 public class ${mediator_name}Builder {
 
-  public static Mediator action(String message) {
-    ${mediator_name} m = new ${mediator_name}();
-    m.setLogMessage(message);
-    return m;
-  }
+    public static Mediator action(String message) {
+        ${mediator_name} m = new ${mediator_name}();
+        m.setLogMessage(message);
+        return m;
+    }
+
 }
 


### PR DESCRIPTION
- Bumped the carbon.messaging.version to 1.0.3.
- Included carbon.messaging as an OSGi import.
- Fixed some code styling issues.
- Added the OS X specific temp file `.DS_Store` to `.gitignore`.